### PR TITLE
Add mobile bottom nav

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import { Analytics } from '@vercel/analytics/react'
 import { Providers } from './providers'
 import { PWAInstallPrompt } from '@/components/PWAInstallPrompt'
+import { MobileBottomNav } from '@/components/MobileBottomNav'
 import "./globals.css";
 
 const inter = Inter({ 
@@ -131,6 +132,7 @@ export default function RootLayout({
         <Providers>
           {children}
           <PWAInstallPrompt />
+          <MobileBottomNav />
         </Providers>
         <SpeedInsights />
         <Analytics />

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Home, PlusCircle, Settings } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useAuth } from '@/contexts/AuthContext'
+
+export function MobileBottomNav() {
+  const { user } = useAuth()
+  const pathname = usePathname()
+
+  const protectedRoutes = ['/dashboard', '/settings', '/profile', '/log', '/photos', '/steps']
+  const isProtectedRoute = protectedRoutes.some((route) => pathname.startsWith(route))
+
+  if (!user || !isProtectedRoute) return null
+
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-50 flex justify-around items-center border-t border-linear-border bg-linear-card pb-safe pt-2 md:hidden"
+      aria-label="Primary"
+    >
+      <Link
+        href="/"
+        className="flex flex-col items-center justify-center text-linear-text-secondary hover:text-linear-text"
+        aria-label="Home"
+      >
+        <Home className="h-6 w-6" />
+        <span className="sr-only">Home</span>
+      </Link>
+
+      <Link
+        href="/log"
+        className={cn(
+          'flex -translate-y-4 items-center justify-center rounded-full bg-linear-purple p-4 text-linear-text shadow-lg'
+        )}
+        aria-label="New Entry"
+      >
+        <PlusCircle className="h-8 w-8" />
+      </Link>
+
+      <Link
+        href="/settings"
+        className="flex flex-col items-center justify-center text-linear-text-secondary hover:text-linear-text"
+        aria-label="Settings"
+      >
+        <Settings className="h-6 w-6" />
+        <span className="sr-only">Settings</span>
+      </Link>
+    </nav>
+  )
+}
+
+export default MobileBottomNav


### PR DESCRIPTION
## Summary
- add a `MobileBottomNav` component with Home, Compose and Settings buttons
- show the bottom nav on all pages via `MobileBottomNav` in `RootLayout`
- only render the nav when a user is authenticated and browsing protected routes

## Testing
- `npm run lint` *(fails with many lint errors)*
- `npm run typecheck` *(fails with TypeScript errors)*
- `npm test` *(fails: 7 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68565b294be08327a93ff78d0db0ebe4