### PR TITLE
Introduce reusable HTTP client for iOS

### DIFF
--- a/apps/ios/LogYourBody/Services/AuthManager.swift
+++ b/apps/ios/LogYourBody/Services/AuthManager.swift
@@ -726,17 +726,19 @@ class AuthManager: NSObject, ObservableObject {
             
             // Create/update profile in Supabase
             let url = URL(string: "\(Constants.supabaseURL)/rest/v1/profiles")!
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.setValue(Constants.supabaseAnonKey, forHTTPHeaderField: "apikey")
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
-            
             let jsonData = try JSONSerialization.data(withJSONObject: [profileData])
-            request.httpBody = jsonData
-            
-            let (_, response) = try await URLSession.shared.data(for: request)
+
+            let (_, response) = try await HTTPClient.shared.sendRequest(
+                url: url,
+                method: "POST",
+                headers: [
+                    "apikey": Constants.supabaseAnonKey,
+                    "Authorization": "Bearer \(token)",
+                    "Content-Type": "application/json",
+                    "Prefer": "resolution=merge-duplicates"
+                ],
+                body: jsonData
+            )
             
             if let httpResponse = response as? HTTPURLResponse {
                 if (200...299).contains(httpResponse.statusCode) {

--- a/apps/ios/LogYourBody/Services/HTTPClient.swift
+++ b/apps/ios/LogYourBody/Services/HTTPClient.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+final class HTTPClient {
+    static let shared = HTTPClient()
+    private init() {}
+
+    enum NetworkError: LocalizedError {
+        case invalidResponse
+    }
+
+    func sendRequest(
+        url: URL,
+        method: String,
+        headers: [String: String] = [:],
+        body: Data? = nil
+    ) async throws -> (Data, HTTPURLResponse) {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        headers.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
+        request.httpBody = body
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+
+        return (data, httpResponse)
+    }
+}


### PR DESCRIPTION
## Summary
- add `HTTPClient` to centralize URLSession usage
- refactor parts of `SupabaseManager` to use the new client
- update AuthManager and HealthKitManager to remove duplicate request code

## Testing
- `npm run lint` *(fails: next lint errors)*
- `npm test` *(fails: jest test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf8fac0483278857d85bc4ffd822