### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios-release-loop.yml
+++ b/.github/workflows/ios-release-loop.yml
@@ -224,6 +224,8 @@ jobs:
 
   deploy-app-store:
     name: Deploy to App Store
+    permissions:
+      contents: read
     needs: [validate-release, build-release]
     if: github.event.inputs.release_type == 'app_store'
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/itstimwhite/LogYourBody/security/code-scanning/64](https://github.com/itstimwhite/LogYourBody/security/code-scanning/64)

To fix the problem, add a `permissions` block to the `deploy-app-store` job, specifying the minimum required permissions for the `GITHUB_TOKEN`. Since this job does not interact with repository contents in a write capacity, the minimal permission `contents: read` should be applied. This change should be made by inserting the following lines under the `deploy-app-store:` job definition (after `name:` and before `needs:` or any other fields).

No new methods, imports, or definitions are needed—this is a purely declarative change within the YAML workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
