### PR TITLE
Fix step metrics reference in dashboard

### DIFF
--- a/apps/ios/LogYourBody/Views/DashboardViewV2.swift
+++ b/apps/ios/LogYourBody/Views/DashboardViewV2.swift
@@ -429,7 +429,7 @@ struct DashboardViewV2: View {
             }
             
             // Steps
-            if let steps = selectedDateMetrics?.stepCount {
+            if let steps = selectedDateMetrics?.steps {
                 MetricStripItem(
                     icon: "figure.walk",
                     value: formatNumber(steps),


### PR DESCRIPTION
## Summary
- correct property used for displaying step metrics in DashboardViewV2

## Testing
- `npm run lint`
- `npm test` *(fails: multiple React component render errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687eec6725448327b1ee7edb8ef786fe